### PR TITLE
Transition from ufpy to awips python package

### DIFF
--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/atcf/AtcfDeckRetriever.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/atcf/AtcfDeckRetriever.py
@@ -1,5 +1,5 @@
 import os
-from ufpy import ThriftClient
+from awips import ThriftClient
 from dynamicserialize.dstypes.com.raytheon.uf.common.datastorage.records import StringDataRecord
 from dynamicserialize.dstypes.com.raytheon.uf.common.datastorage.records import ByteDataRecord
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.atcf.request import RetrieveAtcfDeckRequest

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/atcf/retrieveAtcfDeck.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/atcf/retrieveAtcfDeck.py
@@ -15,7 +15,7 @@
 import os
 import logging
 
-from ufpy import UsageArgumentParser
+from awips import UsageArgumentParser
 import lib.CommHandler as CH
 import AtcfDeckRetriever
 

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/gpd/GpdCliRequestHandler.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/gpd/GpdCliRequestHandler.py
@@ -8,7 +8,7 @@
 ##
 import os
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.gpd.query import GenericPointDataReqMsg
-from ufpy import ThriftClient
+from awips import ThriftClient
 
 
 class GpdCliRequestHandler:

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/gpd/gpd.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/gpd/gpd.py
@@ -8,7 +8,7 @@ import logging
 import sys
 import time
 import GpdCliRequestHandler
-from ufpy import UsageArgumentParser
+from awips import UsageArgumentParser
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.gpd.query import GenericPointDataReqMsg
 from dynamicserialize.dstypes.java.util import Date
 

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ActivityUtil.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ActivityUtil.py
@@ -16,7 +16,7 @@ import re
 import xml.etree.ElementTree as ET
 import sys
 import lib.CommHandler as CH
-from ufpy import ThriftClient
+from awips import ThriftClient
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.pgen.request import RetrieveActivityMapRequest
 
 class ActivityUtil:

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ProductRetriever.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ProductRetriever.py
@@ -1,5 +1,5 @@
 import os
-from ufpy import ThriftClient
+from awips import ThriftClient
 from dynamicserialize.dstypes.com.raytheon.uf.common.datastorage.records import StringDataRecord
 from dynamicserialize.dstypes.com.raytheon.uf.common.datastorage.records import ByteDataRecord
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.pgen.request import RetrieveAllProductsRequest

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ProductStorer.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/ProductStorer.py
@@ -1,5 +1,5 @@
 import os
-from ufpy import ThriftClient
+from awips import ThriftClient
 #from dynamicserialize.dstypes.com.raytheon.uf.common.datastorage.records import ByteDataRecord
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.pgen.request import StoreActivityRequest
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.pgen import ResponseMessageValidate

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/retrieveActivity.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/retrieveActivity.py
@@ -25,7 +25,7 @@ import logging
 import xml.etree.ElementTree as ET
 from tkinter import *
 
-from ufpy import UsageArgumentParser
+from awips import UsageArgumentParser
 import lib.CommHandler as CH
 import ProductRetriever
 import ActivityUtil

--- a/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/storeActivity.py
+++ b/edex/gov.noaa.nws.ncep.edex.tools.cli/impl/src/pgen/storeActivity.py
@@ -9,7 +9,7 @@ import io
 import logging
 import xml.etree.ElementTree as ET
 
-from ufpy import UsageArgumentParser
+from awips import UsageArgumentParser
 from dynamicserialize.dstypes.gov.noaa.nws.ncep.common.dataplugin.pgen import ActivityInfo
 import ProductStorer
 


### PR DESCRIPTION
-Update multiple python scripts across several repos to use awips instead of ufpy:
  -awips2
  -awips2-core
  -awips2-nativelib
  -awips2-ncep
  -awips2-rpm